### PR TITLE
cmock: build_assert filtering

### DIFF
--- a/cmock/gen_headers.py
+++ b/cmock/gen_headers.py
@@ -49,7 +49,8 @@ def gen_headers(header, output, output_wrap):
         r"inline\s+static\s+",
         r"__attribute_const__\s+",
         r"__deprecated\s+",
-        r"BUILD_ASSERT\(.*\)",
+        r"__printf_like\(.*\)",
+        r"BUILD_ASSERT\(.*\);",
     ]
     for pattern in patterns:
         pattern = re.compile(pattern)


### PR DESCRIPTION
- Make sure build assert filtering matches closing semicolon
- Filter out __printf_like so it does not get treated as a function

Closes #4

Signed-off-by: Martin Schröder <info@swedishembedded.com>